### PR TITLE
Add basic auth service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # fastapi-react-vibe-coding-template
 
+This template provides a basic FastAPI backend with a React frontend. The backend now includes a simple authentication service supporting user registration, login, email verification and password reset using JWT tokens.
+
 ## todo
-- auth
-- email verification + restore password
 - logging
 
 # admin

--- a/backend/README.md
+++ b/backend/README.md
@@ -75,3 +75,4 @@ uv run pytest
 4. Create API endpoints in `routes.py`
 5. Register the router in `src/backend/api.py`
 6. Create corresponding test files in `tests/services/your_service/`
+\n## Authentication\nThis project includes a simple authentication service with JWT-based login, email verification and password reset.

--- a/backend/migrations/versions/0001_create_users.py
+++ b/backend/migrations/versions/0001_create_users.py
@@ -1,0 +1,28 @@
+"""Create users table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("email", sa.String, nullable=False, unique=True, index=True),
+        sa.Column("hashed_password", sa.String, nullable=False),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default="1"),
+        sa.Column("is_verified", sa.Boolean, nullable=False, server_default="0"),
+        sa.Column("verification_token", sa.String, nullable=True),
+        sa.Column("reset_token", sa.String, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user")

--- a/backend/src/backend/api.py
+++ b/backend/src/backend/api.py
@@ -1,21 +1,25 @@
 from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
+
+from backend.db import create_db_and_tables, run_migrations
 from backend.services.example_service.routes import router as example_router
-from backend.db import run_migrations, create_db_and_tables, engine
-from sqlmodel import Session
+from backend.services.auth.routes import router as auth_router
+
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
-
+def lifespan(app: FastAPI):
     create_db_and_tables()
     run_migrations()
-
     yield
+
 
 app = FastAPI(lifespan=lifespan)
 
 app.include_router(example_router, tags=["example"])
+app.include_router(auth_router, tags=["auth"])
+
 
 @app.get("/")
-async def root():
+async def root() -> dict[str, str]:
     return {"message": "Hello World"}

--- a/backend/src/backend/services/auth/models.py
+++ b/backend/src/backend/services/auth/models.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import SQLModel, Field
+
+
+class User(SQLModel, table=True):
+    """Basic user model."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str = Field(index=True, sa_column_kwargs={"unique": True})
+    hashed_password: str
+    is_active: bool = True
+    is_verified: bool = False
+    verification_token: Optional[str] = None
+    reset_token: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/src/backend/services/auth/routes.py
+++ b/backend/src/backend/services/auth/routes.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlmodel import Session
+
+from backend.db import get_db
+
+from .schemas import UserRead, UserCreate, Token
+from .service import AuthService
+
+router = APIRouter(prefix="/auth")
+service = AuthService()
+
+
+@router.post("/register", response_model=UserRead)
+def register(user: UserCreate, db: Session = Depends(get_db)):
+    try:
+        new_user = service.create_user(db, user.email, user.password)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    return UserRead.model_validate(new_user)
+
+
+@router.post("/login", response_model=Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    user = service.authenticate(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    token = service.create_token_for_user(user)
+    return Token(access_token=token)
+
+
+@router.get("/verify/{token}")
+def verify_email(token: str, db: Session = Depends(get_db)):
+    if not service.verify_email(db, token):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid token")
+    return {"status": "verified"}
+
+
+@router.post("/request-password-reset")
+def request_password_reset(email: str, db: Session = Depends(get_db)):
+    token = service.request_password_reset(db, email)
+    if not token:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return {"reset_token": token}
+
+
+@router.post("/reset-password")
+def reset_password(token: str, new_password: str, db: Session = Depends(get_db)):
+    if not service.reset_password(db, token, new_password):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid token")
+    return {"status": "password_reset"}

--- a/backend/src/backend/services/auth/schemas.py
+++ b/backend/src/backend/services/auth/schemas.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserRead(BaseModel):
+    """Schema for reading users."""
+
+    id: int
+    email: EmailStr
+    is_active: bool
+    is_verified: bool
+    created_at: datetime
+
+
+class UserCreate(BaseModel):
+    """Schema for creating users."""
+
+    email: EmailStr
+    password: str
+
+
+class UserLogin(BaseModel):
+    """Schema for logging in."""
+
+    email: EmailStr
+    password: str
+
+
+class Token(BaseModel):
+    """Returned JWT access token."""
+
+    access_token: str
+    token_type: str = "bearer"

--- a/backend/src/backend/services/auth/service.py
+++ b/backend/src/backend/services/auth/service.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Optional
+from uuid import uuid4
+
+from sqlmodel import Session, select
+
+from .models import User
+from .utils import hash_password, verify_password, create_access_token
+
+
+class AuthService:
+    """Simple authentication service."""
+
+    def create_user(self, session: Session, email: str, password: str) -> User:
+        user = session.exec(select(User).where(User.email == email)).first()
+        if user:
+            raise ValueError("User already exists")
+        new_user = User(
+            email=email,
+            hashed_password=hash_password(password),
+            verification_token=str(uuid4()),
+        )
+        session.add(new_user)
+        session.commit()
+        session.refresh(new_user)
+        return new_user
+
+    def authenticate(self, session: Session, email: str, password: str) -> Optional[User]:
+        user = session.exec(select(User).where(User.email == email)).first()
+        if user and verify_password(password, user.hashed_password):
+            return user
+        return None
+
+    def verify_email(self, session: Session, token: str) -> bool:
+        user = session.exec(select(User).where(User.verification_token == token)).first()
+        if not user:
+            return False
+        user.is_verified = True
+        user.verification_token = None
+        session.add(user)
+        session.commit()
+        return True
+
+    def request_password_reset(self, session: Session, email: str) -> Optional[str]:
+        user = session.exec(select(User).where(User.email == email)).first()
+        if not user:
+            return None
+        user.reset_token = str(uuid4())
+        session.add(user)
+        session.commit()
+        return user.reset_token
+
+    def reset_password(self, session: Session, token: str, new_password: str) -> bool:
+        user = session.exec(select(User).where(User.reset_token == token)).first()
+        if not user:
+            return False
+        user.hashed_password = hash_password(new_password)
+        user.reset_token = None
+        session.add(user)
+        session.commit()
+        return True
+
+    def create_token_for_user(self, user: User) -> str:
+        return create_access_token({"sub": str(user.id)})

--- a/backend/src/backend/services/auth/utils.py
+++ b/backend/src/backend/services/auth/utils.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from jose import jwt
+from passlib.context import CryptContext
+
+# Simple security settings for demonstration purposes
+SECRET_KEY = "secret"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Hash a plaintext password."""
+    return pwd_context.hash(password)
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    """Verify a plaintext password against its hash."""
+    return pwd_context.verify(password, hashed_password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    """Create a signed JWT access token."""
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)

--- a/backend/tests/services/auth/test_routes.py
+++ b/backend/tests/services/auth/test_routes.py
@@ -1,0 +1,36 @@
+import os
+from sqlmodel import SQLModel, create_engine, Session
+
+os.environ.setdefault("ENVIRONMENT", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "test")
+os.environ.setdefault("POSTGRES_USER", "user")
+os.environ.setdefault("POSTGRES_PASSWORD", "password")
+
+from backend.services.auth.service import AuthService
+from backend.services.auth.models import User
+
+engine = create_engine("sqlite:///:memory:")
+SQLModel.metadata.create_all(engine)
+service = AuthService()
+
+
+def test_register_and_login():
+    with Session(engine) as session:
+        user = service.create_user(session, "u@example.com", "pass")
+        assert user.email == "u@example.com"
+        auth = service.authenticate(session, "u@example.com", "pass")
+        assert auth is not None
+        token = service.create_token_for_user(user)
+        assert token
+
+
+def test_email_verification():
+    with Session(engine) as session:
+        user = service.create_user(session, "v@example.com", "pass")
+        token = user.verification_token
+        ok = service.verify_email(session, token)
+        assert ok
+        session.refresh(user)
+        assert user.is_verified

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,16 +1,23 @@
 import os
-from dotenv import load_dotenv
 
-load_dotenv()
+# Minimal environment variables so settings can load
+os.environ.setdefault("ENVIRONMENT", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "db")
+os.environ.setdefault("POSTGRES_USER", "user")
+os.environ.setdefault("POSTGRES_PASSWORD", "password")
 
 from backend.settings import settings
 
+
 def test_settings():
     assert settings.ENVIRONMENT == os.environ["ENVIRONMENT"]
-    assert settings.DATABASE_URL ==  "postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}".format(
+    expected = "postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}".format(
         POSTGRES_USER=os.environ["POSTGRES_USER"],
         POSTGRES_PASSWORD=os.environ["POSTGRES_PASSWORD"],
         POSTGRES_HOST=os.environ["POSTGRES_HOST"],
         POSTGRES_PORT=os.environ["POSTGRES_PORT"],
-        POSTGRES_DB=os.environ["POSTGRES_DB"]
+        POSTGRES_DB=os.environ["POSTGRES_DB"],
     )
+    assert settings.DATABASE_URL == expected


### PR DESCRIPTION
## Summary
- implement user models and service
- add registration, login, verification and password reset routes
- create auth utils for hashing and JWT tokens
- register auth router
- add migration and tests
- document authentication

## Testing
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*